### PR TITLE
Run command with shell instead of bash

### DIFF
--- a/src/main/java/jenkins/plugins/docker_compose/ExecuteCommandInsideContainer.java
+++ b/src/main/java/jenkins/plugins/docker_compose/ExecuteCommandInsideContainer.java
@@ -115,7 +115,7 @@ public class ExecuteCommandInsideContainer extends DockerComposeCommandOption {
             }
             
             // Set service and command
-            cmd.append(" " + service + " /bin/bash -c \"" + command + "\"");
+            cmd.append(" " + service + " /bin/sh -c \"" + command + "\"");
 
             // Launch command
             LOGGER.info("Executing command '{}' (service: {}, index: {}, workDir: {})", command, service, index, workDir);


### PR DESCRIPTION
Some linux distros (like alpine) don't have bash available, but shell (`sh`) is always there, so use it by default.